### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,31 +13,13 @@ All Doctrine date/time based types are using `DateTime` instances, which are mut
 <?php
 
 // created date might be modified
-// even if it is not "supposed to" by the intentions of the creator
-// (there is no set/modify method on the entity)
+// even if this was not intended by the creator
 var_dump($logRow->getCreatedDate()); // 2015-01-01 00:00:00
-$logRow->getCreatedDate()->modify('+14 days');
+$logRow->getCreatedDate()->modify('+14 days'); // same as: ->getCreatedDate()->add(new \DateInterval('P14D'));
 var_dump($logRow->getCreatedDate()); // 2015-01-15 00:00:00
 ```
 
 You can prevent this behaviour by returning a new instance (cloning) or using [`DateTimeImmutable`](http://php.net/manual/en/class.datetimeimmutable.php) (which returns a new instance when modified). `DateTimeImmutable` is available since PHP 5.5, but Doctrine has not adopted it yet, because it would introduce a [BC break](http://www.doctrine-project.org/jira/browse/DBAL-662). Maybe it will be supported in Doctrine 3.0, but until then you might want to use this package.
-
-Configuration
--------------
-
-Configuration structure with listed default values:
-
-```yaml
-doctrine_date_time_immutable_types:
-    # Choose under which names the types will be registered.
-    register:             add # One of "add"; "replace"; "add_and_replace"; "none"
-```
-
-`register`
-  * `add` - add types as new - suffixed with `_immutable` (e.g. `datetime_immutable`)
-  * `replace` - add types with the same name as original, replacing them (e.g. `datetime`)
-  * `add_and_replace` - combines both previous options (e.g. both `datetime` and `datetime_immutable`)
-  * `none` - does not register any types - can be useful for temporary disabling the registration
 
 Installation
 ------------
@@ -59,3 +41,30 @@ public function registerBundles()
 	);
 }
 ```
+
+Configuration
+-------------
+
+Add this to your `config.yml`:
+
+```yaml
+doctrine_date_time_immutable_types:
+    # Choose under which names the types will be registered.
+    register:             add # One of "add"; "replace"; "add_and_replace"; "none"
+```
+
+`register:`
+  * `add` - add types as new - suffixed with `_immutable` (e.g. `created_at_immutable`)
+  * `replace` - add types with the same name as original, replacing them (e.g. `created_at`)
+  * `add_and_replace` - combines both previous options (e.g. both `created_at` and `created_at_immutable`)
+  * `none` - does not register any types - can be useful for temporary disabling the registration
+
+Usage
+-----
+
+Just use your entities as you normally would, e.g.
+```php
+<?php
+$logRow->getCreatedDate(); // now immutable!
+```
+No need to change anything in your mapping files (e.g. `User.orm.yml`) or entity files (e.g. `User.php`).


### PR DESCRIPTION
Several improvements:
- Showed that PHP's ::add() acts the same as ::modify()
- Moved Configuration below Installation
- Added info that configuration is to be done in config.yml
- At Configuration, changed the (fictional) field name from "datetime" to "created_at" (to clarify that this is an arbitrary name, not Doctrine's type)
- Added Usage section

Question:
"register:add" didn't work for me. Please add an example to the Usage section, how the property is to be loaded. $logRow->getCreatedDateImmutable(); didn't work for me. Do I have to add the setter&getter manually in the entity?
