### PR TITLE
Doctrine DBAL 2.6 implemented immutable types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - nightly

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
 		}
 	],
 	"require": {
+		"doctrine/dbal": "~2.6",
 		"doctrine/doctrine-bundle": "~1.3",
 		"symfony/config": "~3.0",
 		"symfony/dependency-injection": "~3.0",
 		"symfony/http-kernel": "~3.0",
-		"symfony/yaml": "~3.0",
-		"vasek-purchart/doctrine-date-time-immutable-types": "~1.0"
+		"symfony/yaml": "~3.0"
 	},
 	"require-dev": {
 		"consistence/coding-standard": "2.0",

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
 Doctrine DateTimeImmutable Types Bundle
 =======================================
 
-> This is a Symfony Bundle providing integration for the standalone package  
-[`vasek-purchart/doctrine-date-time-immutable-types`](https://github.com/VasekPurchart/Doctrine-Date-Time-Immutable-Types),  
-if you are not using Symfony, follow instructions there.
+> In [Doctrine DBAL 2.6](https://github.com/doctrine/dbal/releases/tag/v2.6.0) immutable DateTime types were added, so this bundle no longer uses [custom DateTime types implementation](https://github.com/VasekPurchart/Doctrine-Date-Time-Immutable-Types), but rather offers control, how the immutable types are registered, offering the possibility to replace the original DateTime types.
 
-### Why would I want to use this?
+> If you cannot upgrade to Doctrine DBAL 2.6 use [1.0 version](https://github.com/VasekPurchart/Doctrine-Date-Time-Immutable-Types-Bundle/tree/1.0) of this bundle, which uses the [`vasek-purchart/doctrine-date-time-immutable-types`](https://github.com/VasekPurchart/Doctrine-Date-Time-Immutable-Types) custom DateTime types implementation.
+
+### Why would I want to use immutable types?
 
 All Doctrine date/time based types are using `DateTime` instances, which are mutable. This can lead to breaking encapsulation and therefore bugs. For two reasons:
 
@@ -60,7 +60,7 @@ $entityManager->persist($product);
 $entityManager->flush();
 ```
 
-You can prevent this behaviour by returning a new instance (cloning) or using [`DateTimeImmutable`](http://php.net/manual/en/class.datetimeimmutable.php) (which returns a new instance when modified). `DateTimeImmutable` is available since PHP 5.5, but Doctrine has not adopted it yet, because it would introduce a [BC break](https://github.com/doctrine/dbal/issues/1882). Maybe it will be supported in Doctrine 3.0, but until then you might want to use this package.
+You can prevent this behaviour by returning a new instance (cloning) or using [`DateTimeImmutable`](http://php.net/manual/en/class.datetimeimmutable.php) (which returns a new instance when modified).
 
 Configuration
 -------------
@@ -71,14 +71,12 @@ Configuration structure with listed default values:
 # app/config/config.yml
 doctrine_date_time_immutable_types:
     # Choose under which names the types will be registered.
-    register: add # One of "add"; "replace"; "add_and_replace"; "none"
+    register: add # One of "add"; "replace"
 ```
 
 `register`
-  * `add` - add types as new - suffixed with `_immutable` (e.g. `datetime_immutable`)
+  * `add` - add types as new - suffixed with `_immutable` (e.g. `datetime_immutable`) - this is already done by DBAL from version 2.6
   * `replace` - replace the original types `date`, `time`, `datetime`, `datetimetz`, i.e. making them immutable
-  * `add_and_replace` - combine both previous options (e.g. both `datetime` and `datetime_immutable`)
-  * `none` - do not register any types - useful for temporary disabling the registration
 
 Usage
 -----

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -12,8 +12,6 @@ class Configuration implements \Symfony\Component\Config\Definition\Configuratio
 	const PARAMETER_REGISTER = 'register';
 
 	const REGISTER_ADD = 'add';
-	const REGISTER_ADD_AND_REPLACE = 'add_and_replace';
-	const REGISTER_NONE = 'none';
 	const REGISTER_REPLACE = 'replace';
 
 	/** @var string */
@@ -36,8 +34,6 @@ class Configuration implements \Symfony\Component\Config\Definition\Configuratio
 					->values([
 						self::REGISTER_ADD,
 						self::REGISTER_REPLACE,
-						self::REGISTER_ADD_AND_REPLACE,
-						self::REGISTER_NONE,
 					])
 					->defaultValue(self::REGISTER_ADD)
 					->end()

--- a/src/DependencyInjection/DoctrineDateTimeImmutableTypesExtension.php
+++ b/src/DependencyInjection/DoctrineDateTimeImmutableTypesExtension.php
@@ -4,11 +4,12 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\DoctrineDateTimeImmutableTypesBundle\DependencyInjection;
 
+use Doctrine\DBAL\Types\DateImmutableType;
+use Doctrine\DBAL\Types\DateTimeImmutableType;
+use Doctrine\DBAL\Types\DateTimeTzImmutableType;
+use Doctrine\DBAL\Types\TimeImmutableType;
+use Doctrine\DBAL\Types\Type;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use VasekPurchart\Doctrine\Type\DateTimeImmutable\DateImmutableType;
-use VasekPurchart\Doctrine\Type\DateTimeImmutable\DateTimeImmutableType;
-use VasekPurchart\Doctrine\Type\DateTimeImmutable\DateTimeTzImmutableType;
-use VasekPurchart\Doctrine\Type\DateTimeImmutable\TimeImmutableType;
 
 class DoctrineDateTimeImmutableTypesExtension
 	extends \Symfony\Component\HttpKernel\DependencyInjection\Extension
@@ -19,10 +20,10 @@ class DoctrineDateTimeImmutableTypesExtension
 
 	/** @var string[] */
 	private static $types = [
-		DateImmutableType::class,
-		DateTimeImmutableType::class,
-		DateTimeTzImmutableType::class,
-		TimeImmutableType::class,
+		Type::DATE_IMMUTABLE => DateImmutableType::class,
+		Type::DATETIME_IMMUTABLE => DateTimeImmutableType::class,
+		Type::DATETIMETZ_IMMUTABLE => DateTimeTzImmutableType::class,
+		Type::TIME_IMMUTABLE => TimeImmutableType::class,
 	];
 
 	public function prepend(ContainerBuilder $container)
@@ -35,20 +36,10 @@ class DoctrineDateTimeImmutableTypesExtension
 		$types = [];
 
 		if (in_array($config[Configuration::PARAMETER_REGISTER], [
-			Configuration::REGISTER_ADD,
-			Configuration::REGISTER_ADD_AND_REPLACE,
-		])) {
-			foreach (self::$types as $type) {
-				$types[$type::NAME] = $type;
-			}
-		}
-
-		if (in_array($config[Configuration::PARAMETER_REGISTER], [
 			Configuration::REGISTER_REPLACE,
-			Configuration::REGISTER_ADD_AND_REPLACE,
 		])) {
-			foreach (self::$types as $type) {
-				$types[str_replace('_immutable', '', $type::NAME)] = $type;
+			foreach (self::$types as $name => $type) {
+				$types[str_replace('_immutable', '', $name)] = $type;
 			}
 		}
 

--- a/tests/DependencyInjection/DoctrineDateTimeImmutableTypesExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineDateTimeImmutableTypesExtensionTest.php
@@ -5,23 +5,15 @@ declare(strict_types = 1);
 namespace VasekPurchart\DoctrineDateTimeImmutableTypesBundle\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
+use Doctrine\DBAL\Types\DateImmutableType;
+use Doctrine\DBAL\Types\DateTimeImmutableType;
+use Doctrine\DBAL\Types\DateTimeTzImmutableType;
+use Doctrine\DBAL\Types\TimeImmutableType;
 use Doctrine\DBAL\Types\Type;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use VasekPurchart\Doctrine\Type\DateTimeImmutable\DateImmutableType;
-use VasekPurchart\Doctrine\Type\DateTimeImmutable\DateTimeImmutableType;
-use VasekPurchart\Doctrine\Type\DateTimeImmutable\DateTimeTzImmutableType;
-use VasekPurchart\Doctrine\Type\DateTimeImmutable\TimeImmutableType;
 
 class DoctrineDateTimeImmutableTypesExtensionTest extends \PHPUnit\Framework\TestCase
 {
-
-	/** @var string[] */
-	private static $immutableTypes = [
-		DateImmutableType::NAME => DateImmutableType::class,
-		DateTimeImmutableType::NAME => DateTimeImmutableType::class,
-		DateTimeTzImmutableType::NAME => DateTimeTzImmutableType::class,
-		TimeImmutableType::NAME => TimeImmutableType::class,
-	];
 
 	/** @var string[] */
 	private static $replaceTypes = [
@@ -37,10 +29,8 @@ class DoctrineDateTimeImmutableTypesExtensionTest extends \PHPUnit\Framework\Tes
 	public function registrationTypesProvider(): array
 	{
 		return [
-			[Configuration::REGISTER_ADD, self::$immutableTypes],
+			[Configuration::REGISTER_ADD, []],
 			[Configuration::REGISTER_REPLACE, self::$replaceTypes],
-			[Configuration::REGISTER_ADD_AND_REPLACE, array_merge(self::$immutableTypes, self::$replaceTypes)],
-			[Configuration::REGISTER_NONE, []],
 		];
 	}
 
@@ -56,7 +46,7 @@ class DoctrineDateTimeImmutableTypesExtensionTest extends \PHPUnit\Framework\Tes
 	public function testDefaultRegisterImmutable()
 	{
 		$types = $this->getDoctrineTypesConfig([]);
-		$this->assertTypes(self::$immutableTypes, $types);
+		$this->assertTypes([], $types);
 	}
 
 	/**


### PR DESCRIPTION
In [Doctrine DBAL 2.6](https://github.com/doctrine/dbal/releases/tag/v2.6.0) immutable DateTime types were added.

However this bundle is still useful to control the types registration, if you want to replace original DateTime types:

Here is what it means for you based on the registration type
* `add`/default - this is currently default state of DBAL 2.6, this bundle is not needed
* `replace` - now has the same effect as previously `add_and_replace`, so keep using this
* `add_and_replace` - deprecated, use `replace` instead
* `none` - deprecated (types are registered by default from DBAL)